### PR TITLE
EKS 내 Redis 적용을 위해 RedisConfig 파일 수정

### DIFF
--- a/backend/src/main/java/com/example/backend/config/RedisConfig.java
+++ b/backend/src/main/java/com/example/backend/config/RedisConfig.java
@@ -1,15 +1,53 @@
 package com.example.backend.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisNode;
+import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@Slf4j
 public class RedisConfig {
 
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        // Sentinel 환경변수 읽기
+        String sentinelMaster = System.getenv("spring.redis.sentinel.master");
+        String sentinelNodes = System.getenv("spring.redis.sentinel.nodes");
+
+        if (sentinelMaster == null || sentinelNodes == null) {
+            log.error("❌ [ENV ERROR] Sentinel 환경변수가 설정되지 않았습니다!");
+            throw new IllegalStateException("Sentinel 환경변수를 찾을 수 없습니다.");
+        }
+
+        log.info("✅ [ENV CHECK] Sentinel Master: {}", sentinelMaster);
+        log.info("✅ [ENV CHECK] Sentinel Nodes: {}", sentinelNodes);
+
+        // Redis Sentinel Configuration 생성
+        RedisSentinelConfiguration sentinelConfig = new RedisSentinelConfiguration();
+        sentinelConfig.master(sentinelMaster);
+
+        // 여러 노드가 있을 경우 쉼표로 구분되었다고 가정 (단일 노드인 경우도 동작)
+        String[] nodes = sentinelNodes.split(",");
+        for (String node : nodes) {
+            String[] parts = node.split(":");
+            if (parts.length == 2) {
+                String host = parts[0].trim();
+                int port = Integer.parseInt(parts[1].trim());
+                sentinelConfig.addSentinel(new RedisNode(host, port));
+            } else {
+                log.warn("❌ [WARNING] Sentinel 노드 형식이 잘못되었습니다: {}", node);
+            }
+        }
+
+        return new LettuceConnectionFactory(sentinelConfig);
+    }
     // Spring Boot의 기본 설정 -> Key와 Value가 Object로 직렬화됨 -> 문제 발생 가능
     // 모든 데이터를 String으로 저장, 관리하기 위해서 RedisTemplate의 Key와 Value Serializer를 StringRedisSerializer로 설정
     @Bean


### PR DESCRIPTION
## Overview

- 기존에는 Redis를 EC2에 배포하였는데, EKS 환경으로 변경한 후 k8s pod로 Redis 배포
- 환경 변수는 k8s 내 configmap에서 관리하며 스프링부트 코드 상에서 해당 설정과 연결하는 과정 필요

## Change Log
- RedisConfig에 연결 코드 추가
    
## To Reviewer

1. k8s 내에 Helm으로 Redis 배포

```
# bitnami 레포지토리 추가&설치(위에서 진행)
# helm repo add bitnami https://charts.bitnami.com/bitnami
# helm repo update

# Redis 배포
helm install sy-redis bitnami/redis \
  --set service.type=ClusterIP \
  --set auth.enabled=false \
  --set volumePermissions.enabled=true \
  --set master.persistence.storageClass="gp2" \
  --set replica.persistence.storageClass="gp2" \
  --set sentinel.enabled=true

kubectl run sy-redis-client --restart='Never'  --image docker.io/bitnami/redis:7.0.3-debian-11-r0 --command -- sleep infinity
```

2. k8s configmap 수정

```
  # Redis
  spring.redis.sentinel.master: "mymaster"
  spring.redis.sentinel.nodes: "sy-redis-headless.default.svc.cluster.local:26379"
```

3. 스프링부트 코드 수정

- 현재 PR 내용
- 처음에만 진행하고 다음에는 해당 이미지로 백엔드 배포하면 됨

- Reference: https://dohk325.notion.site/Kafka-Redis-Helm-1bae1d54939880179fb7d4dd3481c4ad?pvs=4