### PR TITLE
k8s 리소스 코드 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .idea
 terraform/variables.tf
+k8s/config.yaml

--- a/k8s/back-deploy.yaml
+++ b/k8s/back-deploy.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stock-backend-deploy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: back
+  template:
+    metadata:
+      labels:
+        app: back
+    spec:
+      containers:
+      - name: back
+        image: parkseoyeon/sy-backend:v5  # Docker Hub에서 이미지를 가져옵니다.
+        ports:
+        - containerPort: 8080
+        envFrom:
+        - configMapRef:
+            name: app-config

--- a/k8s/back-service.yaml
+++ b/k8s/back-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stock-backend-service
+spec:
+  selector:
+    app: back
+  ports:
+    - protocol: TCP
+      port: 8080 # REACT_APP_STOCK_BACKEND_URL=http://stock-backend-service에 port 번호 작성하지 않으려면 80이어야 함      targetPort: 8080  # 컨테이너가 노출하는 포트
+  type: ClusterIP  # 외부에서 접근할 수 있도록 외부 IP를 할

--- a/k8s/front-deploy.yaml
+++ b/k8s/front-deploy.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stock-frontend-deploy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: front
+  template:
+    metadata:
+      labels:
+        app: front
+    spec:
+      containers:
+      - name: front
+        image: parkseoyeon/sy-frontend:v7  # Docker Hub에서 이미지를 가져옵니다.
+        ports:
+        - containerPort: 80

--- a/k8s/front-service.yaml
+++ b/k8s/front-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: stock-frontend-service
+spec:
+  selector:
+    app: front
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80  # 컨테이너가 노출하는 포트
+  type: ClusterIP  # 외부에서 접근할 수 있도록 외부 IP를 할

--- a/k8s/ingress-https.yaml
+++ b/k8s/ingress-https.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sy-ingress
+  namespace: default
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]' #HTTP,HTTPS
+    alb.ingress.kubernetes.io/ssl-redirect: '443' #HTTP -> HTTPS로 리다이렉션
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:ap-northeast-3:396913715402:certificate/2e2a5846-a493-4497-a77f-c0b76fdeacf0 #SSL 인증서
+spec:
+  ingressClassName: alb
+  rules:
+    - host: seoni.store
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: stock-frontend-service
+                port:
+                  number: 80
+          - path: /api/
+            pathType: Prefix
+            backend:
+              service:
+                name: stock-backend-service
+                port:
+                  number: 8080
+          - path: /ws/stock
+            pathType: Prefix
+            backend:
+              service:
+                name: stock-backend-service
+                port:
+                  number: 8080
+          - path: /subscriptions/update
+            pathType: Prefix
+            backend:
+              service:
+                name: stock-backend-service
+                port:
+                  number: 8080


### PR DESCRIPTION
## Overview
- AWS EKS 환경에서의 배포를 위해 리소스 생성
    
## Change Log
- k8s 리소스 코드 추가  
    
## To Reviewer

1. gitignore된 config.yaml 추가

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: app-config
data:
  spring.application.name: "backend"
  server.port: "8080"
  
  # log level
  logging.level.root: "info"

  # Hibernate (JPA)
  spring.jpa.hibernate.ddl-auto: "create"
  spring.jpa.show-sql: "false"
  spring.jpa.hibernate.naming.physical-strategy: "org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl"
  spring.jpa.properties.hibernate.dialect: "org.hibernate.dialect.MySQLDialect"

  # Stock Base URL
  kis.api.appKey: "{APP_KEY}"
  kis.api.appSecret: "{SECRET_KEY}"
  kis.api.baseUrl: "https://openapi.koreainvestment.com:9443"

  # Redis
  spring.redis.sentinel.master: "mymaster"
  spring.redis.sentinel.nodes: "sy-redis-headless.default.svc.cluster.local:26379"

  # MySQL
  spring.datasource.url: "jdbc:mysql://{RDS_ENDPOINT}.ap-northeast-3.rds.amazonaws.com:3306/stockdatabase?serverTimezone=Asia/Seoul"
  spring.datasource.username: "{USERNAME}"
  spring.datasource.password: "{PASSWORD}"
  spring.datasource.driver-class-name: "com.mysql.cj.jdbc.Driver"

  # Kafka
  spring.kafka.bootstrap-servers: "sy-kafka.default.svc.cluster.local:9092"
  spring.kafka.producer.key-serializer: "org.apache.kafka.common.serialization.StringSerializer"
  spring.kafka.producer.value-serializer: "org.apache.kafka.common.serialization.StringSerializer"
  spring.kafka.consumer.group-id: "volume-rank-consumer-group"
  spring.kafka.consumer.key-deserializer: "org.apache.kafka.common.serialization.StringDeserializer"
  spring.kafka.consumer.value-deserializer: "org.apache.kafka.common.serialization.StringDeserializer"

  # Slack
  slack.web-hook-url: "{WEB_HOOK_URL}"

```

2. Ansible(Helm)또는 Helm 명령어를 사용해 Kafka, Redis, AWS Load Balancer Controller 배포
- 현재 Terraform 코드에는 기본 VPC를 사용하고, RDS가 없으므로 필요한 경우 생성
3. Route53에 도메인(seoni.store) 등록 & ACM 인증서 추가
4. 이후 k8s 폴더의 모든 리소스 실행
- 해당 리소스들을 모두 실행해야 서비스 정상 동작
- 이때 Ingress는 HTTPS 연결되므로 ACM 연결 필요
  - ACM 발급 후 ARN 수정
5. Route53에 Ingress로 생성된 ALB 연결
6. 웹 브라우저로 `https://seoni.store/api/websocket/connect`로 웹소켓 연결
7. 웹 브라우저로 접속 `seoni.store`

## Result

메인페이지 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/a89f6f81-70f1-43a5-a425-b569ba844993" />
<img width="1512" alt="image1" src="https://github.com/user-attachments/assets/18de0dc8-09fa-497b-8cc8-e592b7d28603" />

검색페이지
<img width="1512" alt="image2" src="https://github.com/user-attachments/assets/c91ed6e4-d066-4f35-836d-2df1b11a3c16" />

상세페이지
<img width="1512" alt="image3" src="https://github.com/user-attachments/assets/6af9725d-0fa2-42ab-9cb6-3d770b375803" />
<img width="1512" alt="image4" src="https://github.com/user-attachments/assets/6cd71190-91e4-4cb7-809d-3930e83fbec9" />

